### PR TITLE
Remove global minor mode

### DIFF
--- a/magit-delta.el
+++ b/magit-delta.el
@@ -70,7 +70,6 @@ will be added if not present.")
 
 https://github.com/dandavison/delta"
   :lighter " Magit-Δ"
-  :global t
   (let ((magit-faces-to-override
          '(magit-diff-context-highlight
            magit-diff-added


### PR DESCRIPTION
This minor mode is only meant to be active on magit buffers.